### PR TITLE
chore: set version to new format: 1.0.0-2.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.0.0-2.6.3
+* chore: set version to the new format: 1.0.0-2.6.3
+
 # 2.6.3
 * chore: bump nearcore to 2.6.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "near-lake"
-version = "2.6.3"
+version = "1.0.0-2.6.3"
 dependencies = [
  "actix",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-lake"
-version = "2.6.3"
+version = "1.0.0-2.6.3"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2024"
 


### PR DESCRIPTION
In this PR, a new version format has been applied:
Example: `1.0.0-2.6.3`
 - 1.0.0 - Describes changes to the code of the Near Lake Indexer;
 - 2.6.3 - Indicates which Nearcore tag the indexer is based on.