### PR TITLE
chore: Bump nearcore to 2.7.0-rc.2

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [env]
-NEARCORE_VERSION = "2.7.0-rc.1-4c3f805"
+NEARCORE_VERSION = "2.7.0-rc.2-a2b961b"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.0.0-2.7.0-rc.2
+* chore: bump nearcore to 2.7.0-rc.2
+
 # 1.0.0-2.7.0-rc.1
 * chore: bump nearcore to 2.7.0-rc.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455e9fb7743c6f6267eb2830ccc08686fbb3d13c9a689369562fd4d4ef9ea462"
+checksum = "c18d005c70d2b9c0c1ea8876c039db0ec7fb71164d25c73ccea21bf41fd02171"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -646,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.73.0"
+version = "1.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ac1674cba7872061a29baaf02209fefe499ff034dfd91bd4cc59e4d7741489"
+checksum = "e0a69de9c1b9272da2872af60c7402683e7f45c06267735b4332deacb203239b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -668,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.74.0"
+version = "1.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6a22f077f5fd3e3c0270d4e1a110346cddf6769e9433eb9e6daceb4ca3b149"
+checksum = "f0b161d836fac72bdd5ac1a4cd1cdc38ab888c7af26cfd95f661be4409505e63"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.75.0"
+version = "1.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3258fa707f2f585ee3049d9550954b959002abd59176975150a01d5cf38ae3f"
+checksum = "cb1cd79a3412751a341a28e2cd0d6fa4345241976da427b075a0c0cd5409f886"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -752,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.3"
+version = "0.63.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f77a921dbd2c78ebe70726799787c1d110a2245dd65e39b20923dfdfb2deee"
+checksum = "244f00666380d35c1c76b90f7b88a11935d11b84076ac22a4c014ea0939627af"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -804,15 +804,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f491388e741b7ca73b24130ff464c1478acc34d5b331b7dd0a2ee4643595a15"
+checksum = "f108f1ca850f3feef3009bdcc977be201bca9a91058864d9de0684e64514bee0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.26",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
@@ -1495,8 +1495,20 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2521,9 +2533,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2711,7 +2723,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -3034,15 +3046,15 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.17.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056"
 dependencies = [
- "console",
- "number_prefix",
+ "console 0.16.0",
  "portable-atomic",
  "rayon",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -3052,7 +3064,7 @@ version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
 dependencies = [
- "console",
+ "console 0.15.11",
  "once_cell",
  "pest",
  "pest_derive",
@@ -3553,8 +3565,8 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "futures",
@@ -3572,8 +3584,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3582,8 +3594,8 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "lru 0.12.5",
  "parking_lot 0.12.4",
@@ -3591,8 +3603,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "anyhow",
@@ -3638,8 +3650,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3663,8 +3675,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "near-crypto",
  "near-primitives",
@@ -3675,8 +3687,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "itertools 0.12.1",
@@ -3704,8 +3716,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -3713,8 +3725,8 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3752,7 +3764,7 @@ dependencies = [
  "rayon",
  "reed-solomon-erasure",
  "regex",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "rust-s3",
  "serde",
  "serde_json",
@@ -3769,8 +3781,8 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "near-chain-configs",
@@ -3787,8 +3799,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3798,8 +3810,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "blake2",
  "borsh",
@@ -3823,8 +3835,8 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -3838,8 +3850,8 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3863,16 +3875,16 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "anyhow",
@@ -3897,8 +3909,8 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "near-primitives",
  "serde",
@@ -3906,8 +3918,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -3930,8 +3942,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "awc",
  "futures",
@@ -3943,8 +3955,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -3961,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "near-lake"
-version = "1.0.0-2.7.0-rc.1"
+version = "1.0.0-2.7.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -3994,8 +4006,8 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -4005,8 +4017,8 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "anyhow",
@@ -4051,8 +4063,8 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "base64 0.21.7",
@@ -4076,8 +4088,8 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "borsh",
  "enum-map",
@@ -4094,8 +4106,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "futures",
@@ -4106,8 +4118,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "quote",
  "syn 2.0.104",
@@ -4115,8 +4127,8 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "borsh",
  "near-crypto",
@@ -4127,8 +4139,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4168,8 +4180,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4188,8 +4200,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4218,13 +4230,13 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "near-schema-checker-core",
  "near-schema-checker-macro",
@@ -4232,18 +4244,18 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 
 [[package]]
 name = "near-stdx"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 
 [[package]]
 name = "near-store"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4289,8 +4301,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "awc",
@@ -4306,8 +4318,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "parking_lot 0.12.4",
  "serde",
@@ -4317,8 +4329,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -4333,8 +4345,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "dynasm",
  "dynasmrt",
@@ -4352,8 +4364,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "backtrace",
  "finite-wasm",
@@ -4371,8 +4383,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "anyhow",
  "blst",
@@ -4417,8 +4429,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "indexmap 2.10.0",
  "num-traits",
@@ -4428,8 +4440,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "backtrace",
  "cc",
@@ -4449,8 +4461,8 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -4459,8 +4471,8 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4504,7 +4516,7 @@ dependencies = [
  "object_store",
  "parking_lot 0.12.4",
  "rand 0.8.5",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "serde",
  "serde_ignored",
  "serde_json",
@@ -4531,8 +4543,8 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.7.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.1#4c3f805c343d513281632b01ef82028cc96fbb16"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "borsh",
  "bytesize",
@@ -4645,12 +4657,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4683,7 +4689,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml",
  "rand 0.9.1",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "ring",
  "rustls-pemfile 2.2.0",
  "serde",
@@ -5785,9 +5791,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5795,7 +5801,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -6176,6 +6182,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1375ba8ef45a6f15d83fa8748f1079428295d403d6ea991d09ab100155fbc06d"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6344,16 +6362,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.10.0",
- "schemars",
+ "schemars 0.9.0",
+ "schemars 1.0.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6363,9 +6382,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7328,6 +7347,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-lake"
-version = "1.0.0-2.7.0-rc.1"
+version = "1.0.0-2.7.0-rc.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2024"
 
@@ -31,11 +31,11 @@ tracing-subscriber = "0.3.18"
 tempfile = "=3.14.0"
 
 # Please, update the supported nearcore version in .cargo/config.toml file
-near-client = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.1" }
-near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.1" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.1" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.1" }
-near-o11y = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.1" }
+near-client = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
+near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
+near-o11y = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
 
 [dev-dependencies]
 tar = "0.4"


### PR DESCRIPTION
Automated update of nearcore dependencies to the latest nearcore release tag (2.7.0-rc.2). New package version: 1.0.0-2.7.0-rc.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NEAR core dependencies and related packages to version 2.7.0-rc.2.
  * Upgraded the near-lake package to align with the latest release candidate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->