### PR TITLE
chore: Bump nearcore to 2.12.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [env]
-NEARCORE_VERSION = "2.12.0-rc.2-fadb5c1"
+NEARCORE_VERSION = "2.12.0-1144e31"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.0.0-2.12.0
+* chore: bump nearcore to 2.12.0
+
 # 1.0.0-2.12.0-rc.2
 * chore: bump nearcore to 2.12.0-rc.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "actix-macros",
  "actix-rt",
  "actix_derive",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bytes",
  "crossbeam-channel",
  "futures-core",
@@ -243,9 +243,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.8.17"
+version = "1.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517aa062d8bd9015ee23d6daa5e1c1372328412fdae4e6c4c1be9b69c6ad37a2"
+checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -362,10 +362,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.133.0"
+version = "1.135.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237aba2985e3c0a83e199cc7aa9a64a16c599875bc98170f00932f6199f19922"
+checksum = "f97e3e7e7d86fd26fcdc18bc382da5ca9e8b2ff8d54030d187fd0dac8a236d96"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-sigv4",
@@ -397,10 +398,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.99.0"
+version = "1.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f4055e6099b2ec264abdc0d9bbfffce306c1601809275c861594779a0b04b45"
+checksum = "b647baea49ff551960b904f905681e9b4765a6c4ea08631e89dc52d8bd3f5896"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -421,10 +423,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.101.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f009ba0284c5d696425fd7b4dcc5b189f5726f4041b7a5794daecb3a68d598"
+checksum = "7ae401c65ff288aa7873117fe535cd32b7b1bb0bc43751d28901a1d5f20636b9"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -445,10 +448,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.104.0"
+version = "1.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa6622798e19e6a76b690562085dd4771c736cd48343464a53ab4ae2f2c9f84"
+checksum = "4c80de7bb7d03e9ca8c9fd7b489f20f3948d3f3be91a7953591347d238115408"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -470,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
+checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -562,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -575,7 +579,7 @@ dependencies = [
  "http 1.4.1",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.9",
  "hyper-util",
@@ -592,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.6"
+version = "0.62.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -648,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -688,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.8"
+version = "1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
+checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -750,7 +754,7 @@ dependencies = [
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -866,7 +870,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 1.1.0",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.117",
 ]
 
@@ -876,7 +880,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -884,7 +888,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 2.1.2",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.117",
 ]
 
@@ -896,9 +900,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "bitmaps"
@@ -985,7 +989,7 @@ dependencies = [
  "home",
  "http 1.4.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-named-pipe",
  "hyper-rustls 0.27.9",
  "hyper-util",
@@ -1143,14 +1147,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -1259,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -2778,9 +2782,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2805,7 +2809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2835,7 +2839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.1",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "rustls 0.23.40",
  "rustls-native-certs",
@@ -2850,7 +2854,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2865,7 +2869,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2885,12 +2889,12 @@ dependencies = [
  "futures-util",
  "http 1.4.1",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2906,7 +2910,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3300,9 +3304,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -3326,9 +3330,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.28"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3365,9 +3369,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "lru"
@@ -3560,9 +3564,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -3637,8 +3641,8 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "crossbeam-channel",
  "futures",
@@ -3657,8 +3661,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3667,8 +3671,8 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "lru 0.16.4",
  "parking_lot 0.12.5",
@@ -3676,8 +3680,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3721,8 +3725,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3746,8 +3750,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "near-crypto",
  "near-primitives",
@@ -3758,8 +3762,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "itertools 0.14.0",
  "lru 0.16.4",
@@ -3784,8 +3788,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -3793,8 +3797,8 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3845,8 +3849,8 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "near-chain-primitives",
  "near-chunks-primitives",
@@ -3861,8 +3865,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3872,8 +3876,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "blake2",
  "borsh",
@@ -3897,8 +3901,8 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -3912,8 +3916,8 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
@@ -3937,8 +3941,8 @@ dependencies = [
 
 [[package]]
 name = "near-external-storage"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "futures",
@@ -3954,8 +3958,8 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "near-primitives-core",
 ]
@@ -3972,8 +3976,8 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "futures",
@@ -3999,8 +4003,8 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "near-primitives",
  "serde",
@@ -4008,8 +4012,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "axum",
  "bs58 0.4.0",
@@ -4038,8 +4042,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "futures",
  "near-jsonrpc-primitives",
@@ -4052,8 +4056,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -4070,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "near-lake"
-version = "1.0.0-2.12.0-rc.2"
+version = "1.0.0-2.12.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4104,8 +4108,8 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -4115,8 +4119,8 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4158,8 +4162,8 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "base64 0.21.7",
  "clap",
@@ -4181,8 +4185,8 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "borsh",
  "enum-map",
@@ -4199,8 +4203,8 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "borsh",
  "near-crypto",
@@ -4211,8 +4215,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4254,8 +4258,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4277,8 +4281,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "axum",
  "derive_more",
@@ -4308,13 +4312,13 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "near-schema-checker-core",
  "near-schema-checker-macro",
@@ -4322,18 +4326,18 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 
 [[package]]
 name = "near-stdx"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 
 [[package]]
 name = "near-store"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -4383,8 +4387,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "futures",
  "near-async",
@@ -4397,8 +4401,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "parking_lot 0.12.5",
  "serde",
@@ -4418,8 +4422,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "enumset",
  "finite-wasm 0.5.0",
@@ -4434,8 +4438,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "dynasm",
  "dynasmrt",
@@ -4453,8 +4457,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "backtrace",
  "finite-wasm 0.5.0",
@@ -4472,8 +4476,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "blst",
@@ -4522,8 +4526,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "indexmap 2.14.0",
  "num-traits",
@@ -4533,8 +4537,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "backtrace",
  "cc",
@@ -4554,8 +4558,8 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -4564,8 +4568,8 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4633,8 +4637,8 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.12.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.2#fadb5c1fb2b39f75c181caeff2d598d5532ccdd6"
+version = "2.12.0"
+source = "git+https://github.com/near/nearcore?tag=2.12.0#1144e310f7e70734453167cb07f8cccf28987eb8"
 dependencies = [
  "ahash 0.8.12",
  "borsh",
@@ -4784,7 +4788,7 @@ dependencies = [
  "http 1.4.1",
  "http-body-util",
  "humantime",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "itertools 0.14.0",
  "parking_lot 0.12.5",
  "percent-encoding",
@@ -4823,7 +4827,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5460,7 +5464,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5498,7 +5502,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5679,7 +5683,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -5812,7 +5816,7 @@ dependencies = [
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-rustls 0.27.9",
  "hyper-tls",
  "hyper-util",
@@ -5859,7 +5863,7 @@ dependencies = [
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-rustls 0.27.9",
  "hyper-tls",
  "hyper-util",
@@ -6089,7 +6093,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -6102,7 +6106,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -6138,9 +6142,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe 0.2.1",
  "rustls-pki-types",
@@ -6344,7 +6348,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -6569,6 +6573,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6664,9 +6674,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -6851,7 +6861,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -7001,7 +7011,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe075d7053dae61ac5413a34ea7d4913b6e6207844fd726bdd858b37ff72bf5"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cfg-if",
  "libc",
  "log",
@@ -7114,7 +7124,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -7210,9 +7220,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -7241,7 +7251,7 @@ dependencies = [
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -7280,7 +7290,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bytes",
  "futures-util",
  "http 1.4.1",
@@ -7407,9 +7417,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -7443,9 +7453,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -7558,9 +7568,9 @@ checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7784,7 +7794,7 @@ version = "0.228.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -7797,7 +7807,7 @@ version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9b1e81f3eb254cf7404a82cee6926a4a3ccc5aad80cc3d43608a070c67aa1d7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -7810,7 +7820,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -7822,7 +7832,7 @@ version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "semver",
@@ -7858,7 +7868,7 @@ checksum = "d35aec1e932d00a7c941f816ad589e65ad8db948b9e971bf8ec655a1669f1f67"
 dependencies = [
  "addr2line 0.26.1",
  "async-trait",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bumpalo",
  "cc",
  "cfg-if",
@@ -8549,7 +8559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -8644,18 +8654,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-lake"
-version = "1.0.0-2.12.0-rc.2"
+version = "1.0.0-2.12.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2024"
 
@@ -31,12 +31,12 @@ tracing-subscriber = "0.3.18"
 tempfile = "=3.14.0"
 
 # Please, update the supported nearcore version in .cargo/config.toml file
-near-client = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.2" }
-near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.2" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.2" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.2" }
-near-o11y = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.2" }
-near-async = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.2" }
+near-client = { git = "https://github.com/near/nearcore", tag = "2.12.0" }
+near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.12.0" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.12.0" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.12.0" }
+near-o11y = { git = "https://github.com/near/nearcore", tag = "2.12.0" }
+near-async = { git = "https://github.com/near/nearcore", tag = "2.12.0" }
 
 [dev-dependencies]
 tar = "0.4"


### PR DESCRIPTION
Automated update of nearcore dependencies to the latest nearcore release tag (2.12.0). New package version: 1.0.0-2.12.0